### PR TITLE
Fix instagram link and typo

### DIFF
--- a/content/page/how-to-write/index.md
+++ b/content/page/how-to-write/index.md
@@ -155,7 +155,7 @@ FrontmatterにはYAMLを用いてください。MarkdownLintをパスしてい�
 - [Node.js](https://nodejs.org/ja)
 - [PNPm](https://pnpm.io/ja/)
 
-環境を構築語、ソースコードと依存関係をダウンロードしてください。
+環境を構築後、ソースコードと依存関係をダウンロードしてください。
 
 (CATENASのリポジトリへのアクセス権がない方はフォークしてください。)
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -138,7 +138,7 @@ menu:
 
         - identifier: instagram
           name: Instagram
-          url: https://twitter.com
+          url: https://www.instagram.com/gity_dagashi/
           params:
               icon: brand-instagram
 


### PR DESCRIPTION
GITY のインスタグラムのリンクが https://twitter.com だったので typo とともに修正しました
